### PR TITLE
Add toplevel log metadata project/application/environment

### DIFF
--- a/packages/tracer/src/format.js
+++ b/packages/tracer/src/format.js
@@ -3,9 +3,9 @@ import winston from 'winston';
 const MESSAGE = Symbol.for('message');
 
 const {
-  PROJECT_NAME,
-  APPLICATION_NAME,
-  NODE_ENV,
+  PROJECT,
+  APP_NAME,
+  ENVIRONMENT,
 } = process.env;
 
 const extraLogGroup = ['staging', 'production'];
@@ -16,12 +16,12 @@ const format = winston.format((info) => {
     level,
     timestamp: (new Date()).toISOString(),
   };
-  if (extraLogGroup.includes(NODE_ENV)) {
+  if (extraLogGroup.includes(ENVIRONMENT)) {
     messageObj = {
       ...messageObj,
-      project: PROJECT_NAME,
-      applicationName: APPLICATION_NAME,
-      environment: NODE_ENV,
+      project: PROJECT,
+      application: APP_NAME,
+      environment: ENVIRONMENT,
     };
   }
 


### PR DESCRIPTION
Currently, if we use tracer to log, kibana will parse our log to raw log instead of standard log, since we are missing project/env/application info.
This change is based on BCT latest ENV list and our logging strategy,

ENV list:
```
{ "Name":"APP_NAME","Value":"'${APP_NAME}'" },
    { "Name":"COMMIT","Value":"'${COMMIT}'" },
    { "Name":"ENVIRONMENT","Value":"'${ENVIRONMENT}'" },
    { "Name":"PROJECT","Value":"'${PROJECT}'" },
    { "Name": "ELASTIC_APM_ACTIVE", "Value": "true" },
    { "Name": "ELASTIC_APM_SECRET_TOKEN", "Value": "'$ELASTIC_APM_SECRET_TOKEN'" },
    { "Name": "ELASTIC_APM_SERVICE_NAME", "Value": "'${PROJECT}' '${APP_NAME}'" },
    { "Name": "ELASTIC_APM_SERVER_URL", "Value": "'${ELASTIC_APM_SERVER_URL}'" },
    { "Name": "ELASTIC_APM_SERVICE_VERSION", "Value": "'${COMMIT}'" },
    { "Name": "DEPLOYED_AT", "Value": "'$(date +"%Y%m%d%H%M")'" }
```

Logging example
```
   "level": "info",
    "project": "cex",
    "application": "wallet-service",
    "environment": "production",
```